### PR TITLE
Add stub pipeline orchestrator and service processing hooks

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,31 @@
+"""Simple sequential pipeline orchestrator for service stubs."""
+from typing import Any, Dict
+
+from services.intake import main as intake
+from services.classifier import main as classifier
+from services.graph_extract import main as graph_extract
+from services.embeddings import main as embeddings
+from services.env_synthesis import main as env_synthesis
+from services.safety import main as safety
+from services.runner import main as runner
+from services.integrator import main as integrator
+from services.registrar import main as registrar
+
+SERVICE_SEQUENCE = [
+    intake,
+    classifier,
+    graph_extract,
+    embeddings,
+    env_synthesis,
+    safety,
+    runner,
+    integrator,
+    registrar,
+]
+
+def run_pipeline(data: Any) -> Dict[str, Any]:
+    """Run the stub pipeline by passing a job through each service."""
+    job: Dict[str, Any] = {"data": data, "steps": []}
+    for module in SERVICE_SEQUENCE:
+        job = module.process(job)
+    return job

--- a/services/classifier/main.py
+++ b/services/classifier/main.py
@@ -6,6 +6,12 @@ app = FastAPI(title="classifier Service".title())
 async def root():
     return {"service": "classifier"}
 
+
+def process(job: dict) -> dict:
+    """Append this service's name to the job step trace."""
+    job.setdefault("steps", []).append("classifier")
+    return job
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/embeddings/main.py
+++ b/services/embeddings/main.py
@@ -6,6 +6,12 @@ app = FastAPI(title="embeddings Service".title())
 async def root():
     return {"service": "embeddings"}
 
+
+def process(job: dict) -> dict:
+    """Append this service's name to the job step trace."""
+    job.setdefault("steps", []).append("embeddings")
+    return job
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/env_synthesis/main.py
+++ b/services/env_synthesis/main.py
@@ -6,6 +6,12 @@ app = FastAPI(title="env synthesis Service".title())
 async def root():
     return {"service": "env_synthesis"}
 
+
+def process(job: dict) -> dict:
+    """Append this service's name to the job step trace."""
+    job.setdefault("steps", []).append("env_synthesis")
+    return job
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/graph_extract/main.py
+++ b/services/graph_extract/main.py
@@ -6,6 +6,12 @@ app = FastAPI(title="graph extract Service".title())
 async def root():
     return {"service": "graph_extract"}
 
+
+def process(job: dict) -> dict:
+    """Append this service's name to the job step trace."""
+    job.setdefault("steps", []).append("graph_extract")
+    return job
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/intake/main.py
+++ b/services/intake/main.py
@@ -6,6 +6,12 @@ app = FastAPI(title="intake Service".title())
 async def root():
     return {"service": "intake"}
 
+
+def process(job: dict) -> dict:
+    """Append this service's name to the job step trace."""
+    job.setdefault("steps", []).append("intake")
+    return job
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/integrator/main.py
+++ b/services/integrator/main.py
@@ -6,6 +6,12 @@ app = FastAPI(title="integrator Service".title())
 async def root():
     return {"service": "integrator"}
 
+
+def process(job: dict) -> dict:
+    """Append this service's name to the job step trace."""
+    job.setdefault("steps", []).append("integrator")
+    return job
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/registrar/main.py
+++ b/services/registrar/main.py
@@ -6,6 +6,12 @@ app = FastAPI(title="registrar Service".title())
 async def root():
     return {"service": "registrar"}
 
+
+def process(job: dict) -> dict:
+    """Append this service's name to the job step trace."""
+    job.setdefault("steps", []).append("registrar")
+    return job
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/runner/main.py
+++ b/services/runner/main.py
@@ -6,6 +6,12 @@ app = FastAPI(title="runner Service".title())
 async def root():
     return {"service": "runner"}
 
+
+def process(job: dict) -> dict:
+    """Append this service's name to the job step trace."""
+    job.setdefault("steps", []).append("runner")
+    return job
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/safety/main.py
+++ b/services/safety/main.py
@@ -6,6 +6,12 @@ app = FastAPI(title="safety Service".title())
 async def root():
     return {"service": "safety"}
 
+
+def process(job: dict) -> dict:
+    """Append this service's name to the job step trace."""
+    job.setdefault("steps", []).append("safety")
+    return job
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from pipeline import run_pipeline
+
+EXPECTED_STEPS = [
+    "intake",
+    "classifier",
+    "graph_extract",
+    "embeddings",
+    "env_synthesis",
+    "safety",
+    "runner",
+    "integrator",
+    "registrar",
+]
+
+def test_run_pipeline():
+    result = run_pipeline("data")
+    assert result["steps"] == EXPECTED_STEPS


### PR DESCRIPTION
## Summary
- add `process` hooks to all service stubs to track job progression
- introduce simple sequential pipeline orchestrator
- cover pipeline flow with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b04e364a4483219553840365bc54fa